### PR TITLE
trigger on tab creation, not clicking extension button

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 var windowTiler = new WindowTiler();
 
-// Set up a click handler so that we can tile all the windows.
-chrome.browserAction.onClicked.addListener(windowTiler.start.bind(windowTiler));
+// Ideally, I am looking for a "new window" event, but a "new tab" event will work
+chrome.tabs.onCreated.addListener(windowTiler.start.bind(windowTiler));
 


### PR DESCRIPTION
- *Removed* extension browser action
+ Now runs automatically every time a new tab is opened.